### PR TITLE
Bump monarchmoney API version to 0.1.11

### DIFF
--- a/custom_components/monarchmoney/manifest.json
+++ b/custom_components/monarchmoney/manifest.json
@@ -13,7 +13,7 @@
   "issue_tracker": "https://github.com/sanghviharshit/ha-monarchmoney/issues",
   "quality_scale": "silver",
   "requirements": [
-    "monarchmoney==0.1.0"
+    "monarchmoney==0.1.11"
   ],
   "ssdp": [],
   "version": "0.0.1",


### PR DESCRIPTION
This adds the get_cashflow method to the API, which fixes issue #5.