### PR TITLE
feat: Allow custom session directory

### DIFF
--- a/custom_components/monarchmoney/config_flow.py
+++ b/custom_components/monarchmoney/config_flow.py
@@ -116,7 +116,7 @@ class MonarchConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     async def _test_connection_and_set_token(self) -> None:
         """Test connection and save session token."""
         session_dir_path = self._user_input.get(CONF_SESSION_DIR_PATH, self.hass.config.path(".storage/monarchmoney"))
-        api = MonarchMoney(session_dir_path=session_dir_path)
+        api = MonarchMoney(session_file=session_dir_path)
 
         try:
             # Try login with MFA secret if provided
@@ -228,7 +228,7 @@ class MonarchConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         """Test MFA code and save session token."""
         try:
             session_dir_path = self._user_input.get(CONF_SESSION_DIR_PATH, self.hass.config.path(".storage/monarchmoney"))
-            api = MonarchMoney(session_dir_path=session_dir_path)
+            api = MonarchMoney(session_file=session_dir_path)
             await api.multi_factor_authenticate(
                 self._user_input[CONF_EMAIL],
                 self._user_input[CONF_PASSWORD],

--- a/custom_components/monarchmoney/const.py
+++ b/custom_components/monarchmoney/const.py
@@ -7,6 +7,7 @@ ATTRIBUTION = "Data provided by Monarch"
 CONF_TIMEOUT = "timeout"
 CONF_MFA_CODE = "mfa_code"
 CONF_MFA_SECRET = "mfa_secret"
+CONF_SESSION_DIR_PATH = "session_dir_path"
 
 VALUES_SCAN_INTERVAL = [60, 120, 600, 1800, 3600, 21600, 86400]
 VALUES_TIMEOUT = [10, 15, 30, 45, 60]

--- a/custom_components/monarchmoney/manifest.json
+++ b/custom_components/monarchmoney/manifest.json
@@ -16,6 +16,6 @@
     "monarchmoney==0.1.15"
   ],
   "ssdp": [],
-  "version": "1.1.0",
+  "version": "1.1.2",
   "zeroconf": []
 }

--- a/custom_components/monarchmoney/manifest.json
+++ b/custom_components/monarchmoney/manifest.json
@@ -16,6 +16,6 @@
     "monarchmoney==0.1.15"
   ],
   "ssdp": [],
-  "version": "1.1.0",
+  "version": "1.1.1",
   "zeroconf": []
 }

--- a/custom_components/monarchmoney/update_coordinator.py
+++ b/custom_components/monarchmoney/update_coordinator.py
@@ -20,6 +20,7 @@ from monarchmoney import MonarchMoney, RequireMFAException
 
 from .const import (
     CONF_MFA_SECRET,
+    CONF_SESSION_DIR_PATH,
     DEFAULT_SCAN_INTERVAL,
     DEFAULT_TIMEOUT,
     DOMAIN,
@@ -36,7 +37,8 @@ class MonarchCoordinator(DataUpdateCoordinator):
         """Initialize the coordinator."""
         self._hass = hass
         self._config_entry = config_entry
-        self._api = MonarchMoney()
+        session_dir_path = self._config_entry.data.get(CONF_SESSION_DIR_PATH, self._hass.config.path(".storage/monarchmoney"))
+        self._api = MonarchMoney(session_dir_path=session_dir_path)
         self._auth_lock = (
             asyncio.Lock()
         )  # Prevent concurrent re-authentication attempts
@@ -157,7 +159,8 @@ class MonarchCoordinator(DataUpdateCoordinator):
                 _LOGGER.debug(
                     "Creating fresh MonarchMoney instance for re-authentication"
                 )
-                fresh_api = MonarchMoney()
+                session_dir_path = self._config_entry.data.get(CONF_SESSION_DIR_PATH, self._hass.config.path(".storage/monarchmoney"))
+                fresh_api = MonarchMoney(session_dir_path=session_dir_path)
 
                 if mfa_secret and mfa_secret.strip():
                     _LOGGER.debug("Using stored MFA secret for authentication")

--- a/custom_components/monarchmoney/update_coordinator.py
+++ b/custom_components/monarchmoney/update_coordinator.py
@@ -38,7 +38,7 @@ class MonarchCoordinator(DataUpdateCoordinator):
         self._hass = hass
         self._config_entry = config_entry
         session_dir_path = self._config_entry.data.get(CONF_SESSION_DIR_PATH, self._hass.config.path(".storage/monarchmoney"))
-        self._api = MonarchMoney(session_dir_path=session_dir_path)
+        self._api = MonarchMoney(session_file=session_dir_path)
         self._auth_lock = (
             asyncio.Lock()
         )  # Prevent concurrent re-authentication attempts
@@ -160,7 +160,7 @@ class MonarchCoordinator(DataUpdateCoordinator):
                     "Creating fresh MonarchMoney instance for re-authentication"
                 )
                 session_dir_path = self._config_entry.data.get(CONF_SESSION_DIR_PATH, self._hass.config.path(".storage/monarchmoney"))
-                fresh_api = MonarchMoney(session_dir_path=session_dir_path)
+                fresh_api = MonarchMoney(session_file=session_dir_path)
 
                 if mfa_secret and mfa_secret.strip():
                     _LOGGER.debug("Using stored MFA secret for authentication")


### PR DESCRIPTION
This PR closes #16 by allowing users to specify a custom session directory. This is useful when running in a Docker container where the default directory may not be writable.


NOTE: This was done with gemini-cli and I have not tested it yet (nor do I currently know how to). Will try to test it soon.