### PR TITLE
Add new optional data

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,42 +1,59 @@
 # Monarch for Home Assistant
 
-[![hacs_badge](https://img.shields.io/badge/HACS-Default-41BDF5.svg?style=for-the-badge)](https://github.com/hacs/integration) ![Release badge](https://img.shields.io/github/v/release/sanghviharshit/ha-monarchmoney?style=for-the-badge) [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg?style=for-the-badge)](https://opensource.org/licenses/MIT)
+[![hacs_badge](https://img.shields.io/badge/HACS-Default-41BDF5.svg?style=for-the-badge)](https://github.com/hacs/integration) [![Release badge](https://img.shields.io/github/v/release/sanghviharshit/ha-monarchmoney?style=for-the-badge)](https://github.com/sanghviharshit/ha-monarchmoney/releases/latest) [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg?style=for-the-badge)](https://opensource.org/licenses/MIT)
 
-**Integration for Monarch in Home Assistant**
+**Integration for [Monarch Money](https://www.monarchmoney.com/referral/craudhiyod) in [Home Assistant](https://www.home-assistant.io/)**
 
-[Monarch](https://www.monarchmoney.com/referral/craudhiyod) is modern way to manage your money and lets you track all of your account balances, transactions, and investments in one place.
+Track all your Monarch Money financial data — account balances, net worth, cash flow, investments, and more — directly in Home Assistant.
 
-[Home Assistant](https://www.home-assistant.io/) is an open source home automation package that puts local control and privacy first.
-This integration leverages Monarch's API to collect the accounts' data in Home Assistant.
+## Features
+
+- **Account sensors** — balances grouped by type (Cash, Credit Cards, Investments, Loans, Real Estate, Vehicles, Valuables, etc.)
+- **Net Worth sensor** — total net worth with assets/liabilities breakdown
+- **Cash Flow sensor** — monthly savings, income, and expenses with savings rate
+- **Income & Expense sensors** — totals with per-category breakdowns
+- **Credit Score sensors** *(optional)* — per household member, with score history and change tracking
+- **Investment Holdings sensors** *(optional)* — individual securities with price, quantity, cost basis, and gain/loss
+- **Recurring Transactions calendar** *(optional)* — upcoming bills and subscriptions as calendar events
+- **Refresh button** — manually trigger a data refresh
+- **MFA support** — manual code entry or automatic TOTP via secret key
 
 ## Installation
 
-### HACS Install
+### HACS (Recommended)
 
-- Use HACS and add [ha-monarchmoney](https://github.com/sanghviharshit/ha-monarchmoney) as a custom repo.
-- Go to HACS (Community). Select _Integrations_ and click the + to add a new integration repository. Search for `Monarch` to find this repository, select it and install.
-- Restart Home Assistant after installation.
+1. In HACS, go to **Integrations** and click **+**.
+2. Search for **Monarch** and install.
+3. Restart Home Assistant.
 
-### Manual Install
+### Manual
 
-- Copy the `monarchmoney` folder inside `custom_components` to your Home Assistant's `custom_components` folder.
-- Restart Home Assistant after installation.
+1. Copy the `custom_components/monarchmoney` folder to your Home Assistant `custom_components` directory.
+2. Restart Home Assistant.
 
-### Setup
+## Setup
 
-After restarting go to _Configuration_, _Integrations_, click the + to add a new integration and find the Monarch integration to set up.
+1. Go to **Settings > Devices & Services > Add Integration**.
+2. Search for **Monarch** and follow the prompts.
+3. Log in with your Monarch Money email and password. If MFA is enabled, you'll be prompted for your code (or provide your TOTP secret for automatic MFA).
 
-Log in with your Monarch account.
+## Configuration
 
-The integration will detect all accounts added to your Monarch account. You can override the name and entity ID in Home Assistant's entity settings.
+After setup, go to the integration's **Options** to configure:
+
+| Option | Default | Description |
+|---|---|---|
+| Scan interval | 3600s (1hr) | How often to poll Monarch's API |
+| Timeout | 30s | API request timeout |
+| Credit score | Off | Enable credit score sensors |
+| Investment holdings | Off | Enable per-security holding sensors |
+| Recurring transactions | Off | Enable recurring transactions calendar |
+
+## Planned
+
+- [ ] Add screenshot with masked numbers
+- [ ] Optional sensors for recent transactions (configurable count)
 
 ## Credits
 
-- [monarchmoney](https://github.com/hammem/monarchmoney) from [hammem](https://github.com/hammem)
-
-## ToDo List
-
-- Better exception handling
-- config flow handler for options (timeout, scan interval, monitored categories)
-- Maybe brokerage transactions
-- Maybe investment holdings
+- [monarchmoneycommunity](https://github.com/bradleyseanf/monarchmoneycommunity) (Forked from [monarchmoney](https://github.com/hammem/monarchmoney))

--- a/custom_components/monarchmoney/__init__.py
+++ b/custom_components/monarchmoney/__init__.py
@@ -6,8 +6,16 @@ import logging
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
 
-from .const import DOMAIN, PLATFORMS
+from .const import (
+    CONF_ENABLE_AGGREGATED_HOLDINGS,
+    CONF_ENABLE_CREDIT_SCORE,
+    CONF_ENABLE_HOLDINGS,
+    CONF_ENABLE_RECURRING,
+    DOMAIN,
+    PLATFORMS,
+)
 from .update_coordinator import MonarchCoordinator
 
 _LOGGER = logging.getLogger(__name__)
@@ -34,5 +42,61 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 async def _async_update_options(
     hass: HomeAssistant, config_entry: ConfigEntry
 ) -> None:
-    """Update options."""
+    """Update options and clean up entities for disabled features."""
+    _cleanup_disabled_entities(hass, config_entry)
     await hass.config_entries.async_reload(config_entry.entry_id)
+
+
+def _cleanup_disabled_entities(
+    hass: HomeAssistant, config_entry: ConfigEntry
+) -> None:
+    """Remove entity registry entries for optional features that are now disabled."""
+    ent_reg = er.async_get(hass)
+    entries = er.async_entries_for_config_entry(ent_reg, config_entry.entry_id)
+    options = config_entry.options
+    uid = config_entry.unique_id
+    prefix = f"{DOMAIN}_{uid}_"
+
+    for entry in entries:
+        should_remove = False
+
+        # Calendar entities only come from recurring transactions
+        if entry.domain == "calendar" and not options.get(
+            CONF_ENABLE_RECURRING, False
+        ):
+            should_remove = True
+
+        # Credit score sensors (per-user: credit_score_{user_id}, legacy: credit_score)
+        elif (
+            entry.domain == "sensor"
+            and not options.get(CONF_ENABLE_CREDIT_SCORE, False)
+            and (
+                entry.unique_id == f"{prefix}credit_score"
+                or entry.unique_id.startswith(f"{prefix}credit_score_")
+            )
+        ):
+            should_remove = True
+
+        # Aggregated holding sensors: unique_id contains "holding_agg_"
+        elif (
+            entry.domain == "sensor"
+            and not options.get(CONF_ENABLE_AGGREGATED_HOLDINGS, False)
+            and entry.unique_id.startswith(f"{prefix}holding_agg_")
+        ):
+            should_remove = True
+
+        # Per-account holding sensors: unique_id contains "holding_acct_"
+        elif (
+            entry.domain == "sensor"
+            and not options.get(CONF_ENABLE_HOLDINGS, False)
+            and entry.unique_id.startswith(f"{prefix}holding_acct_")
+        ):
+            should_remove = True
+
+        if should_remove:
+            _LOGGER.debug(
+                "Removing entity %s (feature disabled)", entry.entity_id
+            )
+            ent_reg.async_remove(entry.entity_id)
+
+

--- a/custom_components/monarchmoney/button.py
+++ b/custom_components/monarchmoney/button.py
@@ -63,7 +63,7 @@ class MonarchRefreshButton(CoordinatorEntity, ButtonEntity):
         """Return the device info."""
         return DeviceInfo(
             identifiers={(DOMAIN, self._id)},
-            name="Monarch Money",
+            name="Monarch",
             manufacturer="Monarch Money",
             model="Financial Account",
         )

--- a/custom_components/monarchmoney/button.py
+++ b/custom_components/monarchmoney/button.py
@@ -1,0 +1,69 @@
+"""Button platform for Monarch Money integration."""
+
+import logging
+
+from homeassistant.components.button import ButtonEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity import DeviceInfo
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import DOMAIN
+from .update_coordinator import MonarchCoordinator
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up Monarch Money buttons from a config entry."""
+    coordinator: MonarchCoordinator = hass.data[DOMAIN][config_entry.entry_id]
+    unique_id = config_entry.unique_id
+    async_add_entities(
+        [MonarchRefreshButton(coordinator, unique_id)], True
+    )
+
+
+class MonarchRefreshButton(CoordinatorEntity, ButtonEntity):
+    """Button to refresh Monarch Money accounts from institutions."""
+
+    _attr_has_entity_name = True
+
+    def __init__(self, coordinator, unique_id) -> None:
+        """Initialize the refresh button."""
+        super().__init__(coordinator)
+        self._attr_name = "Refresh Accounts"
+        self._attr_unique_id = f"{DOMAIN}_{unique_id}_refresh_accounts"
+        self._attr_icon = "mdi:refresh"
+        self._id = unique_id
+
+    async def async_press(self) -> None:
+        """Handle the button press."""
+        accounts = self.coordinator.data.get("accounts", [])
+        account_ids = [a["id"] for a in accounts if a.get("id")]
+        if not account_ids:
+            _LOGGER.warning("No accounts found to refresh")
+            return
+
+        _LOGGER.info("Requesting refresh for %d accounts", len(account_ids))
+        try:
+            await self.coordinator.api.request_accounts_refresh(account_ids)
+        except Exception as err:
+            _LOGGER.error("Failed to refresh accounts: %s", err)
+            return
+
+        await self.coordinator.async_request_refresh()
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Return the device info."""
+        return DeviceInfo(
+            identifiers={(DOMAIN, self._id)},
+            name="Monarch Money",
+            manufacturer="Monarch Money",
+            model="Financial Account",
+        )

--- a/custom_components/monarchmoney/calendar.py
+++ b/custom_components/monarchmoney/calendar.py
@@ -125,7 +125,7 @@ class MonarchRecurringCalendar(CoordinatorEntity, CalendarEntity):
         """Return the device info."""
         return DeviceInfo(
             identifiers={(DOMAIN, self._id)},
-            name="Monarch Money",
+            name="Monarch",
             manufacturer="Monarch Money",
             model="Financial Account",
         )

--- a/custom_components/monarchmoney/calendar.py
+++ b/custom_components/monarchmoney/calendar.py
@@ -1,0 +1,131 @@
+"""Calendar platform for Monarch Money recurring transactions."""
+
+from datetime import date, datetime, timedelta
+import logging
+
+from homeassistant.components.calendar import CalendarEntity, CalendarEvent
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.entity import DeviceInfo
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import CONF_ENABLE_RECURRING, DOMAIN
+from .update_coordinator import MonarchCoordinator
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up Monarch Money calendar from a config entry."""
+    if not config_entry.options.get(CONF_ENABLE_RECURRING, False):
+        return
+
+    coordinator: MonarchCoordinator = hass.data[DOMAIN][config_entry.entry_id]
+    unique_id = config_entry.unique_id
+    async_add_entities(
+        [MonarchRecurringCalendar(coordinator, unique_id)], True
+    )
+
+
+class MonarchRecurringCalendar(CoordinatorEntity, CalendarEntity):
+    """Calendar entity for Monarch Money recurring transactions."""
+
+    _attr_has_entity_name = True
+
+    def __init__(self, coordinator, unique_id) -> None:
+        """Initialize the recurring transactions calendar."""
+        super().__init__(coordinator)
+        self._attr_name = "Recurring Transactions"
+        self._attr_unique_id = f"{DOMAIN}_{unique_id}_recurring_calendar"
+        self._id = unique_id
+        self._events: list[CalendarEvent] = []
+
+    @property
+    def event(self) -> CalendarEvent | None:
+        """Return the next upcoming event."""
+        today = date.today()
+        upcoming = [
+            e for e in self._events if e.start >= today
+        ]
+        if upcoming:
+            upcoming.sort(key=lambda e: e.start)
+            return upcoming[0]
+        return None
+
+    async def async_get_events(
+        self, hass: HomeAssistant, start_date: datetime, end_date: datetime
+    ) -> list[CalendarEvent]:
+        """Return events in a specific date range."""
+        s = start_date.date() if isinstance(start_date, datetime) else start_date
+        e = end_date.date() if isinstance(end_date, datetime) else end_date
+        return [
+            ev for ev in self._events if s <= ev.start <= e
+        ]
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        """Handle updated data from the coordinator."""
+        update_data = self.coordinator.data
+        if not update_data:
+            return
+
+        recurring_data = update_data.get("recurring", {})
+        items = recurring_data.get("recurringTransactionItems") or []
+
+        events: list[CalendarEvent] = []
+        for item in items:
+            item_date_str = item.get("date")
+            if not item_date_str:
+                continue
+
+            try:
+                item_date = date.fromisoformat(item_date_str)
+            except (ValueError, TypeError):
+                continue
+
+            stream = item.get("stream") or {}
+            merchant = stream.get("merchant") or {}
+            merchant_name = merchant.get("name", "Unknown")
+            amount = item.get("amount")
+            amount_str = f"${abs(amount):.2f}" if amount is not None else ""
+            category = item.get("category") or {}
+            category_name = category.get("name", "")
+            account = item.get("account") or {}
+            account_name = account.get("displayName", "")
+            frequency = stream.get("frequency", "")
+
+            summary = f"{merchant_name} {amount_str}".strip()
+            description_parts = []
+            if category_name:
+                description_parts.append(f"Category: {category_name}")
+            if account_name:
+                description_parts.append(f"Account: {account_name}")
+            if frequency:
+                description_parts.append(f"Frequency: {frequency}")
+
+            events.append(
+                CalendarEvent(
+                    start=item_date,
+                    end=item_date + timedelta(days=1),
+                    summary=summary,
+                    description="\n".join(description_parts),
+                )
+            )
+
+        self._events = events
+        self.async_write_ha_state()
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Return the device info."""
+        return DeviceInfo(
+            identifiers={(DOMAIN, self._id)},
+            name="Monarch Money",
+            manufacturer="Monarch Money",
+            model="Financial Account",
+        )

--- a/custom_components/monarchmoney/config_flow.py
+++ b/custom_components/monarchmoney/config_flow.py
@@ -15,6 +15,9 @@ from homeassistant.exceptions import HomeAssistantError
 from monarchmoney import MonarchMoney, RequireMFAException, LoginFailedException
 
 from .const import (
+    CONF_ENABLE_CREDIT_SCORE,
+    CONF_ENABLE_HOLDINGS,
+    CONF_ENABLE_RECURRING,
     CONF_MFA_CODE,
     CONF_MFA_SECRET,
     CONF_TIMEOUT,
@@ -75,6 +78,9 @@ OPTIONS_SCHEMA = vol.Schema(
             VALUES_SCAN_INTERVAL
         ),
         vol.Required(CONF_TIMEOUT, default=DEFAULT_TIMEOUT): vol.In(VALUES_TIMEOUT),
+        vol.Optional(CONF_ENABLE_CREDIT_SCORE, default=False): bool,
+        vol.Optional(CONF_ENABLE_HOLDINGS, default=False): bool,
+        vol.Optional(CONF_ENABLE_RECURRING, default=False): bool,
     }
 )
 

--- a/custom_components/monarchmoney/config_flow.py
+++ b/custom_components/monarchmoney/config_flow.py
@@ -15,6 +15,7 @@ from homeassistant.exceptions import HomeAssistantError
 from monarchmoney import MonarchMoney, RequireMFAException, LoginFailedException
 
 from .const import (
+    CONF_ENABLE_AGGREGATED_HOLDINGS,
     CONF_ENABLE_CREDIT_SCORE,
     CONF_ENABLE_HOLDINGS,
     CONF_ENABLE_RECURRING,
@@ -80,6 +81,7 @@ OPTIONS_SCHEMA = vol.Schema(
         vol.Required(CONF_TIMEOUT, default=DEFAULT_TIMEOUT): vol.In(VALUES_TIMEOUT),
         vol.Optional(CONF_ENABLE_CREDIT_SCORE, default=False): bool,
         vol.Optional(CONF_ENABLE_HOLDINGS, default=False): bool,
+        vol.Optional(CONF_ENABLE_AGGREGATED_HOLDINGS, default=False): bool,
         vol.Optional(CONF_ENABLE_RECURRING, default=False): bool,
     }
 )

--- a/custom_components/monarchmoney/const.py
+++ b/custom_components/monarchmoney/const.py
@@ -19,6 +19,7 @@ CONF_MFA_SECRET = "mfa_secret"
 CONF_ENABLE_RECURRING = "enable_recurring"
 CONF_ENABLE_CREDIT_SCORE = "enable_credit_score"
 CONF_ENABLE_HOLDINGS = "enable_holdings"
+CONF_ENABLE_AGGREGATED_HOLDINGS = "enable_aggregated_holdings"
 
 VALUES_SCAN_INTERVAL = [60, 120, 600, 1800, 3600, 21600, 86400]
 VALUES_TIMEOUT = [10, 15, 30, 45, 60]

--- a/custom_components/monarchmoney/const.py
+++ b/custom_components/monarchmoney/const.py
@@ -4,7 +4,11 @@ from homeassistant.const import Platform
 
 DOMAIN = "monarchmoney"
 
-PLATFORMS: list[Platform] = [Platform.SENSOR]
+PLATFORMS: list[Platform] = [
+    Platform.SENSOR,
+    Platform.BUTTON,
+    Platform.CALENDAR,
+]
 
 ATTRIBUTION = "Data provided by Monarch"
 
@@ -12,6 +16,9 @@ CONF_TIMEOUT = "timeout"
 CONF_TOKEN = "token"
 CONF_MFA_CODE = "mfa_code"
 CONF_MFA_SECRET = "mfa_secret"
+CONF_ENABLE_RECURRING = "enable_recurring"
+CONF_ENABLE_CREDIT_SCORE = "enable_credit_score"
+CONF_ENABLE_HOLDINGS = "enable_holdings"
 
 VALUES_SCAN_INTERVAL = [60, 120, 600, 1800, 3600, 21600, 86400]
 VALUES_TIMEOUT = [10, 15, 30, 45, 60]

--- a/custom_components/monarchmoney/manifest.json
+++ b/custom_components/monarchmoney/manifest.json
@@ -13,5 +13,5 @@
   "requirements": [
     "monarchmoneycommunity==1.3.0"
   ],
-  "version": "2.0.0"
+  "version": "1.5.0"
 }

--- a/custom_components/monarchmoney/manifest.json
+++ b/custom_components/monarchmoney/manifest.json
@@ -13,5 +13,5 @@
   "requirements": [
     "monarchmoneycommunity==1.3.0"
   ],
-  "version": "1.4.0"
+  "version": "2.0.0"
 }

--- a/custom_components/monarchmoney/sensor.py
+++ b/custom_components/monarchmoney/sensor.py
@@ -8,10 +8,16 @@ from homeassistant.components.sensor.const import SensorDeviceClass, SensorState
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity import DeviceInfo
+from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import CONF_ENABLE_CREDIT_SCORE, CONF_ENABLE_HOLDINGS, DOMAIN
+from .const import (
+    CONF_ENABLE_AGGREGATED_HOLDINGS,
+    CONF_ENABLE_CREDIT_SCORE,
+    CONF_ENABLE_HOLDINGS,
+    DOMAIN,
+)
 from .update_coordinator import MonarchCoordinator
 from .util import format_date
 
@@ -64,6 +70,19 @@ SENSOR_TYPES_GROUP = {
     },
 }
 
+# Prefix for entity names based on account group
+GROUP_PREFIX = {
+    ATTR_ASSETS: "Assets",
+    ATTR_LIABILITIES: "Liabilities",
+    "OTHER": "Accounts",
+}
+
+# Override display name for categories where the raw name is redundant with the prefix
+CATEGORY_DISPLAY_OVERRIDE = {
+    ATTR_OTHER_ASSET: "Other",
+    ATTR_OTHER_LIABILITY: "Other",
+}
+
 
 async def async_setup_entry(
     hass: HomeAssistant,
@@ -76,18 +95,71 @@ async def async_setup_entry(
     unique_id = config_entry.unique_id
     options = config_entry.options
 
-    categories = SENSOR_TYPES_GROUP.keys()
-    sensors: list[SensorEntity] = [
-        MonarchMoneyCategorySensor(coordinator, category, unique_id)
-        for category in categories
-    ]
+    # Check which account types actually have data for conditional sensors
+    accounts = coordinator.data.get("accounts", []) if coordinator.data else []
+    account_types_present = {
+        a.get("type", {}).get("name") for a in accounts if a.get("type")
+    }
+
+    sensors: list[SensorEntity] = []
+    for category in SENSOR_TYPES_GROUP:
+        # Only create "Other" sensor if accounts of that type exist
+        if category == ATTR_OTHER and "other" not in account_types_present:
+            continue
+        sensors.append(
+            MonarchMoneyCategorySensor(coordinator, category, unique_id)
+        )
     sensors.append(MonarchMoneyNetWorthSensor(coordinator, unique_id))
     sensors.append(MonarchMoneyCashFlowSensor(coordinator, unique_id))
     sensors.append(MonarchMoneyIncomeSensor(coordinator, unique_id))
     sensors.append(MonarchMoneyExpenseSensor(coordinator, unique_id))
 
+    # Migrate: remove legacy cashflow entities renamed to *_this_month
+    ent_reg = er.async_get(hass)
+    legacy_cashflow_ids = [
+        f"{DOMAIN}_{unique_id}_cash_flow",
+        f"{DOMAIN}_{unique_id}_income",
+        f"{DOMAIN}_{unique_id}_expense",
+    ]
+    for legacy_uid in legacy_cashflow_ids:
+        old_eid = ent_reg.async_get_entity_id("sensor", DOMAIN, legacy_uid)
+        if old_eid:
+            _LOGGER.debug("Removing legacy cashflow entity %s", old_eid)
+            ent_reg.async_remove(old_eid)
+
     if options.get(CONF_ENABLE_CREDIT_SCORE, False):
-        sensors.append(MonarchCreditScoreSensor(coordinator, unique_id))
+        credit_data = coordinator.data.get("credit_history", {})
+        snapshots = credit_data.get("creditScoreSnapshots") or []
+        household = credit_data.get("myHousehold", {})
+        household_users = household.get("users", [])
+        user_names = {
+            u["id"]: u.get("displayName") or u.get("name", "Unknown")
+            for u in household_users
+            if u.get("id")
+        }
+
+        # Find users that have credit score data
+        user_ids_with_scores = {
+            snap["user"]["id"]
+            for snap in snapshots
+            if snap.get("user", {}).get("id")
+        }
+
+        for user_id in user_ids_with_scores:
+            display_name = user_names.get(user_id, "Unknown")
+            sensors.append(
+                MonarchCreditScoreSensor(
+                    coordinator, unique_id, user_id, display_name
+                )
+            )
+
+        # Migrate: remove legacy single credit score entity if it exists
+        old_entity_id = ent_reg.async_get_entity_id(
+            "sensor", DOMAIN, f"{DOMAIN}_{unique_id}_credit_score"
+        )
+        if old_entity_id:
+            _LOGGER.debug("Removing legacy credit score entity %s", old_entity_id)
+            ent_reg.async_remove(old_entity_id)
 
     if options.get(CONF_ENABLE_HOLDINGS, False):
         holdings_data = coordinator.data.get("holdings", {})
@@ -110,6 +182,56 @@ async def async_setup_entry(
                     )
                 )
 
+    if options.get(CONF_ENABLE_AGGREGATED_HOLDINGS, False):
+        holdings_data = coordinator.data.get("holdings", {})
+        # Group holdings by ticker across all accounts
+        aggregated: dict[str, dict] = {}
+        for holding_info in holdings_data.values():
+            account = holding_info.get("account", {})
+            holdings_raw = holding_info.get("holdings", {})
+            edges = (
+                holdings_raw.get("portfolio", {})
+                .get("aggregateHoldings", {})
+                .get("edges", [])
+            )
+            for edge in edges:
+                node = edge.get("node", {})
+                security = node.get("security")
+                if security is None:
+                    continue
+                ticker = security.get("ticker", "")
+                if not ticker:
+                    continue
+                if ticker not in aggregated:
+                    aggregated[ticker] = {
+                        "ticker": ticker,
+                        "security_name": security.get("name", ticker),
+                        "security_type": security.get("typeDisplay"),
+                        "current_price": security.get("currentPrice"),
+                        "one_day_change_percent": security.get(
+                            "oneDayChangePercent"
+                        ),
+                        "one_day_change_dollars": security.get(
+                            "oneDayChangeDollars"
+                        ),
+                        "total_value": 0.0,
+                        "quantity": 0.0,
+                        "basis": 0.0,
+                        "accounts": [],
+                    }
+                agg = aggregated[ticker]
+                agg["total_value"] += node.get("totalValue") or 0.0
+                agg["quantity"] += node.get("quantity") or 0.0
+                agg["basis"] += node.get("basis") or 0.0
+                agg["accounts"].append(account.get("displayName", ""))
+
+        for ticker, agg_data in aggregated.items():
+            sensors.append(
+                MonarchAggregatedHoldingSensor(
+                    coordinator, agg_data, unique_id
+                )
+            )
+
     async_add_entities(sensors, True)
 
 
@@ -122,8 +244,10 @@ class MonarchMoneyCategorySensor(CoordinatorEntity, SensorEntity):
         """Pass coordinator to CoordinatorEntity."""
         super().__init__(coordinator, context=category)
         self._account_type = SENSOR_TYPES_GROUP[category]["type"]
-        # self._account_group = SENSOR_TYPES_GROUP[category]["group"]
-        self._attr_name = category
+        group = SENSOR_TYPES_GROUP[category]["group"]
+        prefix = GROUP_PREFIX[group]
+        display_name = CATEGORY_DISPLAY_OVERRIDE.get(category, category)
+        self._attr_name = f"{prefix} {display_name}"
         old_name = f"Monarch {category}"
         self._attr_unique_id = f"{DOMAIN}_{unique_id}_{old_name.lower().replace(' ', '_')}"
         self._state = None  # Keep None for initial state to show "Unknown"
@@ -240,7 +364,7 @@ class MonarchMoneyCategorySensor(CoordinatorEntity, SensorEntity):
         """Return the device info."""
         return DeviceInfo(
             identifiers={(DOMAIN, self._id)},
-            name="Monarch Money",
+            name="Monarch",
             manufacturer="Monarch Money",
             model="Financial Account",
         )
@@ -257,7 +381,7 @@ class MonarchMoneyNetWorthSensor(CoordinatorEntity, SensorEntity):
         self._state = None
         self._assets = None
         self._liabilities = None
-        self._attr_name = "Net Worth"
+        self._attr_name = "Summary Net Worth"
         self._attr_unique_id = f"{DOMAIN}_{unique_id}_net_worth"
         self._id = unique_id
         self._attr_native_unit_of_measurement = "USD"
@@ -332,7 +456,7 @@ class MonarchMoneyNetWorthSensor(CoordinatorEntity, SensorEntity):
         """Return the device info."""
         return DeviceInfo(
             identifiers={(DOMAIN, self._id)},
-            name="Monarch Money",
+            name="Monarch",
             manufacturer="Monarch Money",
             model="Financial Account",
         )
@@ -351,8 +475,8 @@ class MonarchMoneyCashFlowSensor(CoordinatorEntity, SensorEntity):
         self._expenses = None
         self._savings = None
         self._savings_rate = None
-        self._attr_name = "Cash Flow"
-        self._attr_unique_id = f"{DOMAIN}_{unique_id}_cash_flow"
+        self._attr_name = "Cashflow Savings This Month"
+        self._attr_unique_id = f"{DOMAIN}_{unique_id}_cash_flow_this_month"
         self._id = unique_id
         self._attr_native_unit_of_measurement = "USD"
         self._attr_icon = "mdi:chart-sankey-variant"
@@ -406,7 +530,7 @@ class MonarchMoneyCashFlowSensor(CoordinatorEntity, SensorEntity):
         """Return the device info."""
         return DeviceInfo(
             identifiers={(DOMAIN, self._id)},
-            name="Monarch Money",
+            name="Monarch",
             manufacturer="Monarch Money",
             model="Financial Account",
         )
@@ -422,8 +546,8 @@ class MonarchMoneyIncomeSensor(CoordinatorEntity, SensorEntity):
         super().__init__(coordinator)
         self._state = None
         self._income = None
-        self._attr_name = "Income"
-        self._attr_unique_id = f"{DOMAIN}_{unique_id}_income"
+        self._attr_name = "Cashflow Income This Month"
+        self._attr_unique_id = f"{DOMAIN}_{unique_id}_income_this_month"
         self._id = unique_id
         self._attr_native_unit_of_measurement = "USD"
         self._attr_icon = "mdi:bank-plus"
@@ -477,7 +601,7 @@ class MonarchMoneyIncomeSensor(CoordinatorEntity, SensorEntity):
         """Return the device info."""
         return DeviceInfo(
             identifiers={(DOMAIN, self._id)},
-            name="Monarch Money",
+            name="Monarch",
             manufacturer="Monarch Money",
             model="Financial Account",
         )
@@ -493,8 +617,8 @@ class MonarchMoneyExpenseSensor(CoordinatorEntity, SensorEntity):
         super().__init__(coordinator)
         self._state = None
         self._income = None
-        self._attr_name = "Expenses"
-        self._attr_unique_id = f"{DOMAIN}_{unique_id}_expense"
+        self._attr_name = "Cashflow Expenses This Month"
+        self._attr_unique_id = f"{DOMAIN}_{unique_id}_expenses_this_month"
         self._id = unique_id
         self._attr_native_unit_of_measurement = "USD"
         self._attr_icon = "mdi:bank-minus"
@@ -549,26 +673,28 @@ class MonarchMoneyExpenseSensor(CoordinatorEntity, SensorEntity):
         """Return the device info."""
         return DeviceInfo(
             identifiers={(DOMAIN, self._id)},
-            name="Monarch Money",
+            name="Monarch",
             manufacturer="Monarch Money",
             model="Financial Account",
         )
 
 
 class MonarchCreditScoreSensor(CoordinatorEntity, SensorEntity):
-    """Monarch Money credit score sensor."""
+    """Monarch Money credit score sensor for a specific household member."""
 
     _attr_has_entity_name = True
 
-    def __init__(self, coordinator, unique_id) -> None:
+    def __init__(self, coordinator, unique_id, user_id, user_name) -> None:
         """Initialize the credit score sensor."""
         super().__init__(coordinator)
+        self._user_id = user_id
+        self._user_name = user_name
         self._state = None
         self._reported_date = None
         self._previous_score = None
         self._score_change = None
-        self._attr_name = "Credit Score"
-        self._attr_unique_id = f"{DOMAIN}_{unique_id}_credit_score"
+        self._attr_name = f"Credit Score ({user_name})"
+        self._attr_unique_id = f"{DOMAIN}_{unique_id}_credit_score_{user_id}"
         self._id = unique_id
         self._attr_icon = "mdi:credit-card-check"
         self._attr_state_class = SensorStateClass.MEASUREMENT
@@ -586,7 +712,13 @@ class MonarchCreditScoreSensor(CoordinatorEntity, SensorEntity):
             return
 
         credit_data = update_data.get("credit_history", {})
-        snapshots = credit_data.get("creditScoreSnapshots") or []
+        all_snapshots = credit_data.get("creditScoreSnapshots") or []
+
+        # Filter snapshots for this user
+        snapshots = [
+            s for s in all_snapshots
+            if s.get("user", {}).get("id") == self._user_id
+        ]
 
         if not snapshots:
             return
@@ -616,6 +748,7 @@ class MonarchCreditScoreSensor(CoordinatorEntity, SensorEntity):
     def extra_state_attributes(self):
         """Return the state attributes of the sensor."""
         return {
+            "user_name": self._user_name,
             "reported_date": self._reported_date,
             "previous_score": self._previous_score,
             "score_change": self._score_change,
@@ -626,7 +759,7 @@ class MonarchCreditScoreSensor(CoordinatorEntity, SensorEntity):
         """Return the device info."""
         return DeviceInfo(
             identifiers={(DOMAIN, self._id)},
-            name="Monarch Money",
+            name="Monarch",
             manufacturer="Monarch Money",
             model="Financial Account",
         )
@@ -648,9 +781,9 @@ class MonarchHoldingSensor(CoordinatorEntity, SensorEntity):
         self._ticker = security.get("ticker", "")
         security_name = security.get("name", self._ticker)
 
-        self._attr_name = f"{self._ticker or security_name}"
+        self._attr_name = f"Holding {self._ticker or security_name} ({self._account_name})"
         self._attr_unique_id = (
-            f"{DOMAIN}_{unique_id}_{self._account_id}_{self._holding_id}"
+            f"{DOMAIN}_{unique_id}_holding_acct_{self._account_id}_{self._holding_id}"
         )
         self._id = unique_id
         self._attr_native_unit_of_measurement = "USD"
@@ -724,7 +857,116 @@ class MonarchHoldingSensor(CoordinatorEntity, SensorEntity):
         """Return the device info."""
         return DeviceInfo(
             identifiers={(DOMAIN, self._id)},
-            name="Monarch Money",
+            name="Monarch",
+            manufacturer="Monarch Money",
+            model="Financial Account",
+        )
+
+
+class MonarchAggregatedHoldingSensor(CoordinatorEntity, SensorEntity):
+    """Monarch Money aggregated investment holding sensor (across all accounts)."""
+
+    _attr_has_entity_name = True
+
+    def __init__(self, coordinator, agg_data, unique_id) -> None:
+        """Initialize the aggregated holding sensor."""
+        super().__init__(coordinator)
+        self._ticker = agg_data["ticker"]
+        self._attr_name = f"Holding {self._ticker} Total"
+        self._attr_unique_id = (
+            f"{DOMAIN}_{unique_id}_holding_agg_{self._ticker}"
+        )
+        self._id = unique_id
+        self._attr_native_unit_of_measurement = "USD"
+        self._attr_icon = "mdi:chart-areaspline"
+        self._attr_device_class = SensorDeviceClass.MONETARY
+        self._attr_state_class = SensorStateClass.TOTAL
+
+        self._state = None
+        self._attrs: dict = {}
+
+    @property
+    def native_value(self):
+        """Return the native value of the sensor."""
+        return self._state
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        """Handle updated data from the coordinator."""
+        update_data = self.coordinator.data
+        if not update_data:
+            return
+
+        holdings_data = update_data.get("holdings", {})
+
+        total_value = 0.0
+        total_quantity = 0.0
+        total_basis = 0.0
+        accounts: list[str] = []
+        current_price = None
+        security_type = None
+        one_day_change_percent = None
+        one_day_change_dollars = None
+
+        for holding_info in holdings_data.values():
+            account = holding_info.get("account", {})
+            holdings_raw = holding_info.get("holdings", {})
+            edges = (
+                holdings_raw.get("portfolio", {})
+                .get("aggregateHoldings", {})
+                .get("edges", [])
+            )
+            for edge in edges:
+                node = edge.get("node", {})
+                security = node.get("security")
+                if security is None:
+                    continue
+                if security.get("ticker") == self._ticker:
+                    total_value += node.get("totalValue") or 0.0
+                    total_quantity += node.get("quantity") or 0.0
+                    total_basis += node.get("basis") or 0.0
+                    accounts.append(account.get("displayName", ""))
+                    # Price/type is the same across accounts
+                    current_price = security.get("currentPrice")
+                    security_type = security.get("typeDisplay")
+                    one_day_change_percent = security.get(
+                        "oneDayChangePercent"
+                    )
+                    one_day_change_dollars = security.get(
+                        "oneDayChangeDollars"
+                    )
+
+        self._state = round(total_value, 2)
+        self._attrs = {
+            "ticker": self._ticker,
+            "quantity": round(total_quantity, 4),
+            "cost_basis": round(total_basis, 2),
+            "current_price": current_price,
+            "security_type": security_type,
+            "one_day_change_percent": one_day_change_percent,
+            "one_day_change_dollars": one_day_change_dollars,
+            "accounts": accounts,
+            "account_count": len(accounts),
+        }
+        if total_basis > 0:
+            self._attrs["gain_loss"] = round(total_value - total_basis, 2)
+            self._attrs["gain_loss_percent"] = round(
+                ((total_value - total_basis) / total_basis) * 100, 2
+            )
+
+        self.async_write_ha_state()
+
+    @property
+    def extra_state_attributes(self):
+        """Return the state attributes of the sensor."""
+        return self._attrs
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Return the device info."""
+        return DeviceInfo(
+            identifiers={(DOMAIN, self._id)},
+            name="Monarch",
             manufacturer="Monarch Money",
             model="Financial Account",
         )

--- a/custom_components/monarchmoney/sensor.py
+++ b/custom_components/monarchmoney/sensor.py
@@ -11,7 +11,7 @@ from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import DOMAIN
+from .const import CONF_ENABLE_CREDIT_SCORE, CONF_ENABLE_HOLDINGS, DOMAIN
 from .update_coordinator import MonarchCoordinator
 from .util import format_date
 
@@ -74,6 +74,8 @@ async def async_setup_entry(
 
     coordinator: MonarchCoordinator = hass.data[DOMAIN][config_entry.entry_id]
     unique_id = config_entry.unique_id
+    options = config_entry.options
+
     categories = SENSOR_TYPES_GROUP.keys()
     sensors: list[SensorEntity] = [
         MonarchMoneyCategorySensor(coordinator, category, unique_id)
@@ -83,6 +85,30 @@ async def async_setup_entry(
     sensors.append(MonarchMoneyCashFlowSensor(coordinator, unique_id))
     sensors.append(MonarchMoneyIncomeSensor(coordinator, unique_id))
     sensors.append(MonarchMoneyExpenseSensor(coordinator, unique_id))
+
+    if options.get(CONF_ENABLE_CREDIT_SCORE, False):
+        sensors.append(MonarchCreditScoreSensor(coordinator, unique_id))
+
+    if options.get(CONF_ENABLE_HOLDINGS, False):
+        holdings_data = coordinator.data.get("holdings", {})
+        for account_id, holding_info in holdings_data.items():
+            account = holding_info.get("account", {})
+            holdings_raw = holding_info.get("holdings", {})
+            edges = (
+                holdings_raw.get("portfolio", {})
+                .get("aggregateHoldings", {})
+                .get("edges", [])
+            )
+            for edge in edges:
+                node = edge.get("node", {})
+                security = node.get("security")
+                if security is None:
+                    continue
+                sensors.append(
+                    MonarchHoldingSensor(
+                        coordinator, node, account, unique_id
+                    )
+                )
 
     async_add_entities(sensors, True)
 
@@ -517,6 +543,181 @@ class MonarchMoneyExpenseSensor(CoordinatorEntity, SensorEntity):
     def extra_state_attributes(self):
         """Return the state attributes of the sensor."""
         return {"categories": self._expense_cats}
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Return the device info."""
+        return DeviceInfo(
+            identifiers={(DOMAIN, self._id)},
+            name="Monarch Money",
+            manufacturer="Monarch Money",
+            model="Financial Account",
+        )
+
+
+class MonarchCreditScoreSensor(CoordinatorEntity, SensorEntity):
+    """Monarch Money credit score sensor."""
+
+    _attr_has_entity_name = True
+
+    def __init__(self, coordinator, unique_id) -> None:
+        """Initialize the credit score sensor."""
+        super().__init__(coordinator)
+        self._state = None
+        self._reported_date = None
+        self._previous_score = None
+        self._score_change = None
+        self._attr_name = "Credit Score"
+        self._attr_unique_id = f"{DOMAIN}_{unique_id}_credit_score"
+        self._id = unique_id
+        self._attr_icon = "mdi:credit-card-check"
+        self._attr_state_class = SensorStateClass.MEASUREMENT
+
+    @property
+    def native_value(self):
+        """Return the native value of the sensor."""
+        return self._state
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        """Handle updated data from the coordinator."""
+        update_data = self.coordinator.data
+        if not update_data:
+            return
+
+        credit_data = update_data.get("credit_history", {})
+        snapshots = credit_data.get("creditScoreSnapshots") or []
+
+        if not snapshots:
+            return
+
+        # Sort by date to ensure we get the most recent
+        sorted_snapshots = sorted(
+            snapshots,
+            key=lambda s: s.get("reportedDate", ""),
+        )
+
+        latest = sorted_snapshots[-1]
+        self._state = latest.get("score")
+        self._reported_date = latest.get("reportedDate")
+
+        if len(sorted_snapshots) >= 2:
+            previous = sorted_snapshots[-2]
+            self._previous_score = previous.get("score")
+            if self._state is not None and self._previous_score is not None:
+                self._score_change = self._state - self._previous_score
+        else:
+            self._previous_score = None
+            self._score_change = None
+
+        self.async_write_ha_state()
+
+    @property
+    def extra_state_attributes(self):
+        """Return the state attributes of the sensor."""
+        return {
+            "reported_date": self._reported_date,
+            "previous_score": self._previous_score,
+            "score_change": self._score_change,
+        }
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Return the device info."""
+        return DeviceInfo(
+            identifiers={(DOMAIN, self._id)},
+            name="Monarch Money",
+            manufacturer="Monarch Money",
+            model="Financial Account",
+        )
+
+
+class MonarchHoldingSensor(CoordinatorEntity, SensorEntity):
+    """Monarch Money investment holding sensor."""
+
+    _attr_has_entity_name = True
+
+    def __init__(self, coordinator, holding_node, account, unique_id) -> None:
+        """Initialize the holding sensor."""
+        super().__init__(coordinator)
+        self._holding_id = holding_node.get("id")
+        self._account_id = account.get("id")
+        self._account_name = account.get("displayName", "")
+
+        security = holding_node.get("security", {})
+        self._ticker = security.get("ticker", "")
+        security_name = security.get("name", self._ticker)
+
+        self._attr_name = f"{self._ticker or security_name}"
+        self._attr_unique_id = (
+            f"{DOMAIN}_{unique_id}_{self._account_id}_{self._holding_id}"
+        )
+        self._id = unique_id
+        self._attr_native_unit_of_measurement = "USD"
+        self._attr_icon = "mdi:chart-line"
+        self._attr_device_class = SensorDeviceClass.MONETARY
+        self._attr_state_class = SensorStateClass.TOTAL
+
+        self._state = None
+        self._attrs: dict = {}
+
+    @property
+    def native_value(self):
+        """Return the native value of the sensor."""
+        return self._state
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        """Handle updated data from the coordinator."""
+        update_data = self.coordinator.data
+        if not update_data:
+            return
+
+        holdings_data = update_data.get("holdings", {})
+        account_holdings = holdings_data.get(self._account_id, {})
+        holdings_raw = account_holdings.get("holdings", {})
+        edges = (
+            holdings_raw.get("portfolio", {})
+            .get("aggregateHoldings", {})
+            .get("edges", [])
+        )
+
+        for edge in edges:
+            node = edge.get("node", {})
+            if node.get("id") == self._holding_id:
+                self._state = node.get("totalValue")
+                security = node.get("security") or {}
+                self._attrs = {
+                    "ticker": security.get("ticker"),
+                    "quantity": node.get("quantity"),
+                    "cost_basis": node.get("basis"),
+                    "current_price": security.get("currentPrice"),
+                    "security_type": security.get("typeDisplay"),
+                    "one_day_change_percent": security.get(
+                        "oneDayChangePercent"
+                    ),
+                    "one_day_change_dollars": security.get(
+                        "oneDayChangeDollars"
+                    ),
+                    "account_name": self._account_name,
+                }
+                # Calculate gain/loss
+                basis = node.get("basis")
+                total_value = node.get("totalValue")
+                if basis is not None and total_value is not None:
+                    self._attrs["gain_loss"] = round(total_value - basis, 2)
+                    if basis > 0:
+                        self._attrs["gain_loss_percent"] = round(
+                            ((total_value - basis) / basis) * 100, 2
+                        )
+                break
+
+        self.async_write_ha_state()
+
+    @property
+    def extra_state_attributes(self):
+        """Return the state attributes of the sensor."""
+        return self._attrs
 
     @property
     def device_info(self) -> DeviceInfo:

--- a/custom_components/monarchmoney/strings.json
+++ b/custom_components/monarchmoney/strings.json
@@ -50,12 +50,14 @@
           "scan_interval": "Scan Interval",
           "timeout": "Timeout",
           "enable_credit_score": "Enable Credit Score",
-          "enable_holdings": "Enable Investment Holdings",
+          "enable_holdings": "Enable Investment Holdings (per account)",
+          "enable_aggregated_holdings": "Enable Aggregated Investment Holdings",
           "enable_recurring": "Enable Recurring Transactions Calendar"
         },
         "data_description": {
           "enable_credit_score": "Track your credit score as a sensor.",
           "enable_holdings": "Create a sensor per investment holding in each brokerage account. Adds one API call per brokerage account per poll.",
+          "enable_aggregated_holdings": "Create one sensor per unique security (e.g. VTI) with totals aggregated across all brokerage accounts. Requires the same API calls as per-account holdings.",
           "enable_recurring": "Show upcoming recurring transactions in a calendar entity."
         }
       }

--- a/custom_components/monarchmoney/strings.json
+++ b/custom_components/monarchmoney/strings.json
@@ -48,7 +48,15 @@
       "init": {
         "data": {
           "scan_interval": "Scan Interval",
-          "timeout": "Timeout"
+          "timeout": "Timeout",
+          "enable_credit_score": "Enable Credit Score",
+          "enable_holdings": "Enable Investment Holdings",
+          "enable_recurring": "Enable Recurring Transactions Calendar"
+        },
+        "data_description": {
+          "enable_credit_score": "Track your credit score as a sensor.",
+          "enable_holdings": "Create a sensor per investment holding in each brokerage account. Adds one API call per brokerage account per poll.",
+          "enable_recurring": "Show upcoming recurring transactions in a calendar entity."
         }
       }
     }

--- a/custom_components/monarchmoney/translations/en.json
+++ b/custom_components/monarchmoney/translations/en.json
@@ -50,12 +50,14 @@
           "scan_interval": "Scan Interval",
           "timeout": "Timeout",
           "enable_credit_score": "Enable Credit Score",
-          "enable_holdings": "Enable Investment Holdings",
+          "enable_holdings": "Enable Investment Holdings (per account)",
+          "enable_aggregated_holdings": "Enable Aggregated Investment Holdings",
           "enable_recurring": "Enable Recurring Transactions Calendar"
         },
         "data_description": {
           "enable_credit_score": "Track your credit score as a sensor.",
           "enable_holdings": "Create a sensor per investment holding in each brokerage account. Adds one API call per brokerage account per poll.",
+          "enable_aggregated_holdings": "Create one sensor per unique security (e.g. VTI) with totals aggregated across all brokerage accounts. Requires the same API calls as per-account holdings.",
           "enable_recurring": "Show upcoming recurring transactions in a calendar entity."
         }
       }

--- a/custom_components/monarchmoney/translations/en.json
+++ b/custom_components/monarchmoney/translations/en.json
@@ -48,7 +48,15 @@
       "init": {
         "data": {
           "scan_interval": "Scan Interval",
-          "timeout": "Timeout"
+          "timeout": "Timeout",
+          "enable_credit_score": "Enable Credit Score",
+          "enable_holdings": "Enable Investment Holdings",
+          "enable_recurring": "Enable Recurring Transactions Calendar"
+        },
+        "data_description": {
+          "enable_credit_score": "Track your credit score as a sensor.",
+          "enable_holdings": "Create a sensor per investment holding in each brokerage account. Adds one API call per brokerage account per poll.",
+          "enable_recurring": "Show upcoming recurring transactions in a calendar entity."
         }
       }
     }

--- a/custom_components/monarchmoney/update_coordinator.py
+++ b/custom_components/monarchmoney/update_coordinator.py
@@ -3,6 +3,7 @@
 import asyncio
 import calendar as cal_module
 from datetime import date, timedelta
+import importlib.metadata
 import logging
 import time
 from typing import Any
@@ -20,6 +21,7 @@ from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, Upda
 from monarchmoney import MonarchMoney, RequireMFAException
 
 from .const import (
+    CONF_ENABLE_AGGREGATED_HOLDINGS,
     CONF_ENABLE_CREDIT_SCORE,
     CONF_ENABLE_HOLDINGS,
     CONF_ENABLE_RECURRING,
@@ -237,8 +239,10 @@ class MonarchCoordinator(DataUpdateCoordinator):
                     data[key] = result
                     _LOGGER.debug("Fetched %s data", key)
 
-        # Holdings: one call per brokerage account (opt-in)
-        if options.get(CONF_ENABLE_HOLDINGS, False):
+        # Holdings: one call per brokerage account (opt-in, used by both per-account and aggregated)
+        if options.get(CONF_ENABLE_HOLDINGS, False) or options.get(
+            CONF_ENABLE_AGGREGATED_HOLDINGS, False
+        ):
             brokerage_accounts = [
                 a
                 for a in data["accounts"]

--- a/custom_components/monarchmoney/update_coordinator.py
+++ b/custom_components/monarchmoney/update_coordinator.py
@@ -1,7 +1,8 @@
 """Update coordinator for Monarch Money integration."""
 
 import asyncio
-from datetime import timedelta
+import calendar as cal_module
+from datetime import date, timedelta
 import logging
 import time
 from typing import Any
@@ -19,6 +20,9 @@ from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, Upda
 from monarchmoney import MonarchMoney, RequireMFAException
 
 from .const import (
+    CONF_ENABLE_CREDIT_SCORE,
+    CONF_ENABLE_HOLDINGS,
+    CONF_ENABLE_RECURRING,
     CONF_MFA_SECRET,
     CONF_TOKEN,
     DEFAULT_SCAN_INTERVAL,
@@ -167,21 +171,106 @@ class MonarchCoordinator(DataUpdateCoordinator):
                 _LOGGER.error("Failed to authenticate with stored credentials: %s", err)
                 return False
 
+    @property
+    def api(self) -> MonarchMoney:
+        """Return the API client."""
+        return self._api
+
     async def _fetch_api_data(self) -> dict[str, Any]:
         """Fetch all data sets from the Monarch API."""
-        data: dict[str, Any] = {"accounts": [], "categories": [], "cashflow": {}}
+        data: dict[str, Any] = {
+            "accounts": [],
+            "categories": [],
+            "cashflow": {},
+        }
+        options = self.config_entry.options
 
-        accounts = await self._api.get_accounts()
-        data["accounts"] = accounts.get("accounts") or []
-        _LOGGER.debug("Fetched %d accounts from API", len(data["accounts"]))
+        # Core data (always fetched in parallel)
+        accounts_coro = self._api.get_accounts()
+        categories_coro = self._api.get_transaction_categories()
+        cashflow_coro = self._api.get_cashflow()
 
-        categories = await self._api.get_transaction_categories()
-        data["categories"] = categories.get("categories") or []
-        _LOGGER.debug("Fetched %d categories from API", len(data["categories"]))
+        accounts_raw, categories_raw, cashflow_raw = await asyncio.gather(
+            accounts_coro, categories_coro, cashflow_coro
+        )
 
-        cashflow = await self._api.get_cashflow()
-        data["cashflow"] = cashflow or {}
-        _LOGGER.debug("Fetched cashflow data: %s", bool(data["cashflow"]))
+        data["accounts"] = accounts_raw.get("accounts") or []
+        data["categories"] = categories_raw.get("categories") or []
+        data["cashflow"] = cashflow_raw or {}
+        _LOGGER.debug(
+            "Fetched %d accounts, %d categories from API",
+            len(data["accounts"]),
+            len(data["categories"]),
+        )
+
+        # Optional data groups (only if enabled)
+        optional_tasks: dict[str, Any] = {}
+
+        if options.get(CONF_ENABLE_CREDIT_SCORE, False):
+            optional_tasks["credit_history"] = self._api.get_credit_history()
+
+        if options.get(CONF_ENABLE_RECURRING, False):
+            today = date.today()
+            start = today.replace(day=1)
+            # End of next month
+            if today.month == 12:
+                next_month = today.replace(year=today.year + 1, month=1, day=1)
+            else:
+                next_month = today.replace(month=today.month + 1, day=1)
+            _, last_day = cal_module.monthrange(next_month.year, next_month.month)
+            end = next_month.replace(day=last_day)
+            optional_tasks["recurring"] = self._api.get_recurring_transactions(
+                start_date=start.strftime("%Y-%m-%d"),
+                end_date=end.strftime("%Y-%m-%d"),
+            )
+
+        if optional_tasks:
+            keys = list(optional_tasks.keys())
+            results = await asyncio.gather(
+                *optional_tasks.values(), return_exceptions=True
+            )
+            for key, result in zip(keys, results):
+                if isinstance(result, Exception):
+                    _LOGGER.error("Failed to fetch %s: %s", key, result)
+                    data[key] = {}
+                else:
+                    data[key] = result
+                    _LOGGER.debug("Fetched %s data", key)
+
+        # Holdings: one call per brokerage account (opt-in)
+        if options.get(CONF_ENABLE_HOLDINGS, False):
+            brokerage_accounts = [
+                a
+                for a in data["accounts"]
+                if a.get("type", {}).get("name") == "brokerage"
+                and not a.get("isHidden", False)
+            ]
+            holdings_data: dict[str, Any] = {}
+            if brokerage_accounts:
+                holdings_results = await asyncio.gather(
+                    *(
+                        self._api.get_account_holdings(int(a["id"]))
+                        for a in brokerage_accounts
+                    ),
+                    return_exceptions=True,
+                )
+                for account, result in zip(brokerage_accounts, holdings_results):
+                    if isinstance(result, Exception):
+                        _LOGGER.error(
+                            "Failed to fetch holdings for %s: %s",
+                            account.get("displayName"),
+                            result,
+                        )
+                    else:
+                        holdings_data[account["id"]] = {
+                            "account": account,
+                            "holdings": result,
+                        }
+                _LOGGER.debug(
+                    "Fetched holdings for %d brokerage accounts",
+                    len(holdings_data),
+                )
+            data["holdings"] = holdings_data
 
         return data
 


### PR DESCRIPTION
# Summary

Adds three opt-in data features - credit scores, investment holdings, and recurring transactions - along with a manual refresh button. Introduces two new HA platforms (`button`, `calendar`) and refactors the coordinator to fetch all core data in parallel. Also renames several existing sensors for clarity and migrates stale legacy entity IDs on upgrade.

### Added
- **Credit score sensors** (optional) — per-household-member credit score with `reported_date`, `previous_score`, and `score_change` attributes; enable via Options
- **Investment holding sensors** (optional) — per-security value within each brokerage account, including quantity, cost basis, and gain/loss; enable via Options
- **Aggregated holding sensors** (optional) — total position per ticker aggregated across all brokerage accounts; enable via Options
- **Recurring transactions calendar** (optional) — upcoming bills and subscriptions as HA calendar events (current month + next month window); enable via Options
- **Refresh button** — manually trigger account refresh from institutions without waiting for the next poll cycle
- Four new options in the config Options flow: `Enable Credit Score`, `Enable Investment Holdings (per account)`, `Enable Aggregated Investment Holdings`, `Enable Recurring Transactions Calendar`

### Changed
- Core API calls (`get_accounts`, `get_transaction_categories`, `get_cashflow`) are now fetched in parallel, reducing poll latency
- Optional data (credit history, recurring) also fetched in parallel with isolated per-task error handling
- Sensor display names updated for clarity:
  - `Cash Flow` → `Cashflow Savings This Month`
  - `Income` → `Cashflow Income This Month`
  - `Expenses` → `Cashflow Expenses This Month`
  - `Net Worth` → `Summary Net Worth`
  - Account category sensors now prefixed with their group (e.g. `Assets Cash`, `Liabilities Credit Cards`)
- Device name shortened from `"Monarch Money"` to `"Monarch"` across all entities
- README rewritten with feature list, updated install/setup steps, and options configuration table

### Fixed
- Disabling an optional feature in Options now removes stale entity registry entries (no more ghost entities for credit score, holdings, or recurring calendar)