### PR TITLE
fix: handle null security in 401k/mutual fund holdings

### DIFF
--- a/custom_components/monarchmoney/models.py
+++ b/custom_components/monarchmoney/models.py
@@ -50,6 +50,7 @@ class Account:
     include_in_net_worth: bool
     is_hidden: bool
     is_asset: bool
+    holdings_count: int
 
     @classmethod
     def from_api(cls, data: dict[str, Any]) -> Account:
@@ -66,6 +67,7 @@ class Account:
             include_in_net_worth=data.get("includeInNetWorth", False),
             is_hidden=data.get("isHidden", False),
             is_asset=data.get("isAsset", True),
+            holdings_count=data.get("holdingsCount", 0),
         )
 
 
@@ -290,6 +292,22 @@ class AccountHoldings:
         holdings: list[Holding] = []
         for edge in edges:
             node = edge.get("node") or {}
+            # Some account types (e.g. 401k mutual funds) return security=None
+            # but embed the security details inside a nested "holdings" list.
+            if not node.get("security"):
+                nested = (node.get("holdings") or [{}])[0]
+                if nested:
+                    node = {
+                        **node,
+                        "security": {
+                            "ticker": nested.get("ticker"),
+                            "name": nested.get("name", ""),
+                            "currentPrice": nested.get("closingPrice", 0.0),
+                            "typeDisplay": nested.get("typeDisplay", ""),
+                            "oneDayChangePercent": 0.0,
+                            "oneDayChangeDollars": 0.0,
+                        },
+                    }
             holding = Holding.from_api(node)
             if holding is not None:
                 holdings.append(holding)

--- a/custom_components/monarchmoney/models.py
+++ b/custom_components/monarchmoney/models.py
@@ -8,7 +8,10 @@ dependency and MUST NOT import from any other integration module.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+import logging
 from typing import Any
+
+_LOGGER = logging.getLogger(__name__)
 
 
 # ---------------------------------------------------------------------------
@@ -286,6 +289,7 @@ class AccountHoldings:
         cls, account: Account | dict[str, Any], holdings_data: dict[str, Any]
     ) -> AccountHoldings:
         """Build from an Account object (or raw dict) and holdings response."""
+        account_obj = account if isinstance(account, Account) else Account.from_api(account)
         portfolio = holdings_data.get("portfolio") or {}
         agg = portfolio.get("aggregateHoldings") or {}
         edges = agg.get("edges") or []
@@ -295,6 +299,9 @@ class AccountHoldings:
             # Some account types (e.g. 401k mutual funds) return security=None
             # but embed the security details inside a nested "holdings" list.
             if not node.get("security"):
+                _LOGGER.debug(
+                    "Holding node missing security, raw node: %s", node
+                )
                 nested = (node.get("holdings") or [{}])[0]
                 if nested:
                     node = {
@@ -308,10 +315,29 @@ class AccountHoldings:
                             "oneDayChangeDollars": 0.0,
                         },
                     }
+                    # The aggregate totalValue is computed from the security's
+                    # closing price, which lags 1-2 days for non-listed funds
+                    # (CITs). When this is the account's only holding, the
+                    # account's synced balance is the fresher number Monarch
+                    # itself displays — prefer it.
+                    if len(edges) == 1 and account_obj.display_balance:
+                        balance = account_obj.display_balance
+                        quantity = node.get("quantity") or 0.0
+                        _LOGGER.debug(
+                            "Single nested holding: overriding totalValue %s "
+                            "with account balance %s",
+                            node.get("totalValue"),
+                            balance,
+                        )
+                        node = {**node, "totalValue": balance}
+                        if quantity > 0:
+                            node["security"] = {
+                                **node["security"],
+                                "currentPrice": balance / quantity,
+                            }
             holding = Holding.from_api(node)
             if holding is not None:
                 holdings.append(holding)
-        account_obj = account if isinstance(account, Account) else Account.from_api(account)
         return cls(
             account=account_obj,
             holdings=holdings,

--- a/custom_components/monarchmoney/update_coordinator.py
+++ b/custom_components/monarchmoney/update_coordinator.py
@@ -229,6 +229,15 @@ class MonarchCoordinator(DataUpdateCoordinator[MonarchData]):
         if options.get(CONF_ENABLE_HOLDINGS, False) or options.get(
             CONF_ENABLE_AGGREGATED_HOLDINGS, False
         ):
+            for a in data.accounts:
+                _LOGGER.debug(
+                    "Account %s (id=%s): type=%s holdings_count=%d is_hidden=%s",
+                    a.display_name,
+                    a.id,
+                    a.account_type.name,
+                    a.holdings_count,
+                    a.is_hidden,
+                )
             brokerage_accounts = [
                 a
                 for a in data.accounts
@@ -250,8 +259,12 @@ class MonarchCoordinator(DataUpdateCoordinator[MonarchData]):
                             result,
                         )
                     else:
-                        data.holdings.append(
-                            AccountHoldings.from_api(account, result)
+                        acct_holdings = AccountHoldings.from_api(account, result)
+                        data.holdings.append(acct_holdings)
+                        _LOGGER.debug(
+                            "Parsed %d holdings for %s",
+                            len(acct_holdings.holdings),
+                            account.display_name,
                         )
                 _LOGGER.debug(
                     "Fetched holdings for %d brokerage accounts",


### PR DESCRIPTION
## Problem

Monarch Money returns `security: null` on aggregate holding nodes for some
account types (e.g. employer 401k plans holding collective investment
trusts). The security details are instead nested inside a `holdings[]`
array on the node:

```json
{
  "quantity": 100.0,
  "totalValue": 35729.00,
  "lastSyncedAt": "2026-06-12",
  "security": null,
  "holdings": [{
    "type": "mutual_fund",
    "name": "Example S&P 500 DC CIT",
    "ticker": null,
    "closingPrice": 357.29,
    "closingPriceUpdatedAt": "2026-06-10T00:00:00+00:00"
  }]
}
```

This causes two distinct bugs:

1. **Holding dropped entirely.** `Holding.from_api` returns `None` when
   `security` is missing, so no sensor is ever created for the holding.
2. **Stale value even when parsed.** The aggregate `totalValue` is
   computed by Monarch from the security's `closingPrice`, which lags 1–2
   days for funds that are not exchange-listed (note
   `closingPriceUpdatedAt` trailing `lastSyncedAt` above). A sensor built
   from it never matches the account balance shown in the Monarch UI.

## Why the first commit alone was insufficient

The first commit on this branch fixed only bug 1 (nested-security
fallback). Live testing showed the recovered holding reported a value
noticeably behind the Monarch UI because of bug 2 — correct per the API
response, but computed from a two-day-old closing price.

## Fix

- `security: null` → fall back to `holdings[0]` and map its fields into
  the shape `Security.from_api` expects (first commit).
- When that fallback fires **and** the holding is the account's only
  holding, use the account's synced `displayBalance` as the holding value
  and derive `currentPrice = balance / quantity` (second commit). This is
  the same figure the Monarch UI displays for the account. Multi-holding
  accounts are left untouched, since the balance cannot be attributed to
  a single holding.
- Debug logging added so similar account types can be diagnosed from
  logs: per-account `type`/`holdings_count`/`is_hidden`, a raw dump of
  any aggregate node missing `security`, and per-account parsed holding
  counts.

## Scope

Holdings with a normal `security` object — including typical 401k plans
holding listed mutual funds or ETFs — never enter this code path and are
completely unaffected. The override applies only to `security: null`
holdings, which were previously dropped entirely (no sensor created), so
no existing working sensor changes behavior. Within that case, if the
account carries a cash position alongside its single holding, the sensor
reports the full account balance — the same figure the Monarch UI shows
for the account.

## Testing

- Verified against a live 401k account holding a single CIT fund: the
  sensor now matches the Monarch UI balance exactly; debug log confirms
  the override (`overriding totalValue ... with account balance ...`).
- Standalone parse test of `AccountHoldings.from_api` with a captured
  `security: null` payload (value overridden, price derived) and a
  normal listed-security payload (passes through unchanged).